### PR TITLE
Add emailSuggestion to IdentityUI login methods

### DIFF
--- a/Source/Manager/IdentityManager.swift
+++ b/Source/Manager/IdentityManager.swift
@@ -369,7 +369,7 @@ public class IdentityManager: IdentityManagerProtocol {
      - parameter persistUser: whether the login status should be persistent on app's relaunches
      - parameter completion: a callback that is called after the credential is checked.
      */
-    public func login(username: Identifier, password: String, scopes: [String] = [], persistUser: Bool, completion: @escaping NoValueCallback) {
+    public func login(username: Identifier, emailSuggestion: String? = nil, password: String, scopes: [String] = [], persistUser: Bool, completion: @escaping NoValueCallback) {
         log(from: self, "\(username) logging in with scopes: \(scopes), persist: \(persistUser)")
 
         let wrappedCompletion: NoValueCallback = { [weak self] result in

--- a/Source/Manager/IdentityManagerOverloads.swift
+++ b/Source/Manager/IdentityManagerOverloads.swift
@@ -40,8 +40,8 @@ public extension IdentityManagerProtocol {
     }
 
     /// - SeeAlso: `IdentityManager.login(...)`
-    func login(email: EmailAddress, password: String, scopes: [String] = [], persistUser: Bool, completion: @escaping NoValueCallback) {
-        return login(username: Identifier(email), password: password, scopes: scopes, persistUser: persistUser, completion: completion)
+    func login(email: EmailAddress, emailSuggestion: String? = nil, password: String, scopes: [String] = [], persistUser: Bool, completion: @escaping NoValueCallback) {
+        return login(username: Identifier(email), emailSuggestion: emailSuggestion, password: password, scopes: scopes, persistUser: persistUser, completion: completion)
     }
     /// - SeeAlso: `IdentityManager.signup(...)`
     func signup(email: EmailAddress, password: String, persistUser: Bool, completion: @escaping NoValueCallback) {

--- a/Source/Manager/Protocols/IdentityManagerProtocol.swift
+++ b/Source/Manager/Protocols/IdentityManagerProtocol.swift
@@ -26,7 +26,7 @@ public protocol IdentityManagerProtocol: AnyObject {
     func validate(oneTimeCode: String, for _: Identifier, scopes: [String], persistUser: Bool, completion: @escaping NoValueCallback)
 
     ///
-    func login(username: Identifier, password: String, scopes: [String], persistUser: Bool, completion: @escaping NoValueCallback)
+    func login(username: Identifier, emailSuggestion: String?, password: String, scopes: [String], persistUser: Bool, completion: @escaping NoValueCallback)
 
     ///
     func signup(

--- a/Source/UI/IdentityUI.swift
+++ b/Source/UI/IdentityUI.swift
@@ -253,6 +253,7 @@ public class IdentityUI {
     public func presentIdentityProcess(
         from viewController: UIViewController,
         loginMethod: LoginMethod,
+        emailSuggestion: String?,
         localizedTeaserText: String? = nil,
         scopes: [String] = []
     ) {
@@ -261,6 +262,7 @@ public class IdentityUI {
         start(
             input: .byLoginMethod(
                 loginMethod,
+                emailSuggestion: emailSuggestion,
                 presentingViewController: viewController,
                 localizedTeaserText: localizedTeaserText,
                 scopes: scopes
@@ -385,6 +387,7 @@ extension IdentityUI: FlowCoordinator {
     enum Input {
         case byLoginMethod(
             LoginMethod,
+            emailSuggestion: String?,
             presentingViewController: UIViewController,
             localizedTeaserText: String?,
             scopes: [String]
@@ -433,7 +436,7 @@ extension IdentityUI {
     func initializeAndShow(input: Input, completion: @escaping (Output) -> Void) {
         let presentingViewController: UIViewController
         switch input {
-        case let .byRoute(_, vc), let .byLoginMethod(_, vc, _, _):
+        case let .byRoute(_, vc), let .byLoginMethod(_, _, vc, _, _):
             presentingViewController = vc
         }
 
@@ -461,9 +464,10 @@ extension IdentityUI {
         switch input {
         case let .byRoute(route, vc):
             handleRouteForUnpresentedUI(route: route, byPresentingIn: vc, client: client, completion: completion)
-        case let .byLoginMethod(loginMethod, vc, localizedTeaserText, scopes):
+        case let .byLoginMethod(loginMethod, emailSuggestion, vc, localizedTeaserText, scopes):
             let identifierViewController = makeIdentifierViewController(
                 loginMethod: loginMethod,
+                emailSuggestion: emailSuggestion,
                 localizedTeaserText: localizedTeaserText,
                 scopes: scopes,
                 kind: client.kind,
@@ -479,6 +483,7 @@ extension IdentityUI {
 
     private func makeIdentifierViewController(
         loginMethod: LoginMethod,
+        emailSuggestion: String?,
         localizedTeaserText: String?,
         scopes: [String],
         kind: Client.Kind?,
@@ -490,6 +495,7 @@ extension IdentityUI {
         )
         let viewModel = IdentifierViewModel(
             loginMethod: loginMethod,
+            emailSuggestion: emailSuggestion,
             kind: kind,
             merchantName: merchantName,
             localizedTeaserText: localizedTeaserText,
@@ -681,6 +687,7 @@ extension IdentityUI {
 
         let viewController = makeIdentifierViewController(
             loginMethod: route.loginMethod,
+            emailSuggestion: nil,
             localizedTeaserText: nil,
             scopes: scopes,
             kind: client.kind,

--- a/Source/UI/Interactors/SigninInteractor.swift
+++ b/Source/UI/Interactors/SigninInteractor.swift
@@ -10,8 +10,8 @@ class SigninInteractor {
         self.identityManager = identityManager
     }
 
-    func login(username: Identifier, password: String, scopes: [String], completion: @escaping (Result<User, ClientError>) -> Void) {
-        identityManager.login(username: username, password: password, scopes: scopes, persistUser: false) { [weak self] result in
+    func login(username: Identifier, emailSuggestion: String? = nil, password: String, scopes: [String], completion: @escaping (Result<User, ClientError>) -> Void) {
+        identityManager.login(username: username, emailSuggestion: emailSuggestion, password: password, scopes: scopes, persistUser: false) { [weak self] result in
             guard let strongSelf = self else { return }
             switch result {
             case .success:

--- a/Source/UI/Screens/Identifier/IdentifierViewController.swift
+++ b/Source/UI/Screens/Identifier/IdentifierViewController.swift
@@ -157,12 +157,18 @@ class IdentifierViewController: IdentityUIViewController {
         case .email, .password:
             showEmailAddress()
             viewToEnsureVisibilityOfAfterKeyboardAppearance = emailAddress
-            if let savedEmail = Settings.value(forKey: Constants.EmailStorageLabel) {
+            if let emailSuggestion = viewModel.emailSuggestion {
+                emailAddress.text = emailSuggestion
+            } else if let savedEmail = Settings.value(forKey: Constants.EmailStorageLabel) {
                 emailAddress.text = savedEmail as? String
             }
         case let .emailWithPrefilledValue(prefilledEmail), let .passwordWithPrefilledEmail(prefilledEmail):
             showEmailAddress()
-            emailAddress.text = prefilledEmail.normalizedString
+            if let emailSuggestion = viewModel.emailSuggestion {
+                emailAddress.text = emailSuggestion
+            } else {
+                emailAddress.text = prefilledEmail.normalizedString
+            }
         case .phone:
             showPhoneNumber()
             viewToEnsureVisibilityOfAfterKeyboardAppearance = phoneNumber

--- a/Source/UI/Screens/Identifier/IdentifierViewModel.swift
+++ b/Source/UI/Screens/Identifier/IdentifierViewModel.swift
@@ -8,6 +8,7 @@ import Foundation
 ///
 class IdentifierViewModel {
     let loginMethod: LoginMethod
+    let emailSuggestion: String?
     let localizedTeaserText: String?
     let localizationBundle: Bundle
     let kind: Client.Kind
@@ -23,6 +24,7 @@ class IdentifierViewModel {
 
     init(
         loginMethod: LoginMethod,
+        emailSuggestion: String? = nil,
         kind: Client.Kind?,
         merchantName: String,
         localizedTeaserText: String?,
@@ -30,6 +32,7 @@ class IdentifierViewModel {
         locale: Locale
     ) {
         self.loginMethod = loginMethod
+        self.emailSuggestion = emailSuggestion
         self.kind = kind ?? .internal
         self.merchantName = merchantName
         self.localizedTeaserText = localizedTeaserText

--- a/Tests/Utils/TestingIdentityManager.swift
+++ b/Tests/Utils/TestingIdentityManager.swift
@@ -63,9 +63,9 @@ class TestingIdentityManager: IdentityManagerProtocol {
         }
     }
 
-    func login(username: Identifier, password: String, scopes: [String] = [], persistUser: Bool, completion: @escaping NoValueCallback) {
+    func login(username: Identifier, loginHint: String?, password: String, scopes: [String] = [], persistUser: Bool, completion: @escaping NoValueCallback) {
         Utils.waitUntilDone(completion) { [unowned self] in
-            self.identityManager.login(username: username, password: password, scopes: scopes, persistUser: persistUser, completion: $0)
+            self.identityManager.login(username: username, emailSuggestion: emailSuggestion, password: password, scopes: scopes, persistUser: persistUser, completion: $0)
         }
     }
 


### PR DESCRIPTION
Add a new parameter `emailSuggestion` to the `IdentityUI.presentLoginUI` method. The value provided for the `emailSuggestion` parameter will pre-fill the email field.